### PR TITLE
Incremental deploy

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -439,8 +439,10 @@ export const deploy = async ({ yes, bucket, userAgent }: DeployArguments = {}) =
             }
         }
 
-        spinner.text = `Writing object ETags to Cache`;
-        await writeObjectsToCache(objects);
+        if (config.cacheS3ObjectList) {
+            spinner.text = `Writing object ETags to Cache`;
+            await writeObjectsToCache(objects);
+        }
 
         spinner.succeed('Synced.');
         if (config.enableS3StaticWebsiteHosting) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const CACHE_FILES = {
     params: path.join('.cache', 's3.params.json'),
     routingRules: path.join('.cache', 's3.routingRules.json'),
     redirectObjects: path.join('.cache', 's3.redirectObjects.json'),
+    objectList: path.join('.cache', 's3.objectList.json'),
 };
 
 export type GatsbyRedirect = Parameters<Actions['createRedirect']>[0];
@@ -91,6 +92,13 @@ export interface S3PluginOptions extends PluginOptions {
     // but could be useful for preventing Cloud formation Stack Drift or suppressing Terraform noise if you don't need
     // the static website hosting functionality.
     enableS3StaticWebsiteHosting?: boolean;
+
+    // If true, the list of objects in s3 is stored in a file in the cache directory.
+    // The public directory is compared to that list on deployment instead of scanning
+    // the bucket in s3.
+    // This can be useful for large sites to speed up deployments, by not requiring
+    // them to list all objects in s3 on every deployment.
+    cacheS3ObjectList?: boolean;
 
     // Max number of files to upload in parallel.
     parallelLimit?: number;

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,3 +24,11 @@ export const getS3WebsiteDomainUrl = (region: string): string => {
     }
     return `s3-website.${region}.amazonaws.com`;
 };
+
+export function pick<T extends Record<string, unknown>, K extends keyof T>(object: T, ...paths: K[]): Pick<T, K> {
+    const newObj = {} as Pick<T, K>;
+    for (const k of paths) {
+        newObj[k] = object[k];
+    }
+    return newObj;
+}


### PR DESCRIPTION
PR opened for reference while we use this fork

Seems to save a median of 4.7 seconds on staging:

yarn deploy |   | Median
-- | -- | --
56574.70556 |   | 23110.081
21134.1396 |   |  
31296.57008 |   |  
23110.08099 |   |  
21630.29352 |   |  
24856.90786 |   |  
22652.96233 |   |  
  |   |  
27213.16924 |   | 27815.1756
22446.04643 |   |  
30356.71192 |   |  
29643.15946 |   |  
24594.29362 |   |  
44389.38312 |   |  
34202.8643 |   |  
19453.93909 |   |  
28913.15792 |   |  
27806.65061 |   |  
27815.17555 |   |  
